### PR TITLE
Fix live layout to make flash messages work on LiveViews.

### DIFF
--- a/lib/kudzu_web/live/article_live.ex
+++ b/lib/kudzu_web/live/article_live.ex
@@ -1,5 +1,5 @@
 defmodule KudzuWeb.ArticleLive do
-  use Phoenix.LiveView
+  use KudzuWeb, :live_view
   alias KudzuWeb.Credentials
 
   def render(assigns) do

--- a/lib/kudzu_web/templates/layout/live.html.leex
+++ b/lib/kudzu_web/templates/layout/live.html.leex
@@ -1,68 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <title><%= assigns[:page_title] || "Kudzu Live" %></title>
-    <link rel="stylesheet" href="<%= Routes.static_path(@socket, "/css/app.css") %>"/>
-    <%= Metatags.print_tags(@socket) %>
-    <%= csrf_meta_tag() %>
-  </head>
-  <body>
-    <header>
-      <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
-        <a class="navbar-brand" href="/">Kudzu</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-          <ul class='navbar-nav'>
-            <li class='nav-item'>
-              <a href="/about" class='nav-link'>About</a>
-            </li>
-          </ul>
-          <ul class="navbar-nav ml-auto">
-            <%= if Pow.Plug.current_user(@socket) do %>
-              <li class="nav-item">
-                <%= link @current_user.email, to: Routes.pow_registration_path(@socket, :edit), class: "nav-link" %>
-              </li>
-              <li class="nav-item">
-                <%= link "Sign Out", to: Routes.pow_session_path(@socket, :delete), method: :delete, class: "nav-link" %>
-              </li>
-            <% else %>
-              <li class='nav-item'>
-                <%= link "Register", to: Routes.pow_registration_path(@socket, :new), class: "nav-link" %>
-              </li>
-              <li class='nav-item'>
-                <%= link "Sign in", to: Routes.pow_session_path(@socket, :new), class: "nav-link" %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      </nav>
-    </header>
-
-    <main role="main" class="container">
-      <%= unless is_nil(get_flash(@socket, :info)) do %>
-        <p class="alert alert-info" role="alert"><%= get_flash(@socket, :info) %></p>
-      <% end %>
-      <%= unless is_nil(get_flash(@socket, :error)) do %>
-        <p class="alert alert-danger" role="alert"><%= get_flash(@socket, :error) %></p>
-      <% end %>
-      <%= unless is_nil(get_flash(@socket, :success)) do %>
-        <p class="alert alert-danger" role="alert"><%= get_flash(@socket, :success) %></p>
-      <% end %>
-      <%= render @view_module, @view_template, assigns %>
-    </main>
-
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-
-    <script type="text/javascript" src="<%= Routes.static_path(@socket, "/js/app.js") %>"></script>
-
-    <script src="https://kit.fontawesome.com/4527f8207b.js" crossorigin="anonymous"></script>
-  </body>
-</html>
+<%= unless is_nil(live_flash(@flash, :info)) do %>
+  <p class="alert alert-info" role="alert"><%= live_flash(@flash, :info) %></p>
+<% end %>
+<%= unless is_nil(live_flash(@flash, :error)) do %>
+  <p class="alert alert-danger" role="alert"><%= live_flash(@flash, :error) %></p>
+<% end %>
+<%= unless is_nil(live_flash(@flash, :success)) do %>
+  <p class="alert alert-danger" role="alert"><%= live_flash(@flash, :success) %></p>
+<% end %>
+<%= @inner_content %>


### PR DESCRIPTION
Resolves #12 

- The `ArticleLive` Liveview wasn't using the live layout `live.html.leex`, so only the non-live flash messages were available on the page. I had to `use KudzuWeb, :live_view` in the Liveview definitions for it to use the live layout.
- The live layout is currently a sub-layout of the default `app.html.eex` layout, so I've modified `live.html.leex` to only contain the flash message and `@inner_content`.
- `live_flash` should be used instead of `get_flash` in Liveviews.

More informations here:
https://hexdocs.pm/phoenix_live_view/live-layouts.html
https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.Helpers.html#live_flash/2